### PR TITLE
autolinking improvement for android

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+      	sourceDir: 'lib/android'
+      }
+    }
+  }
+};


### PR DESCRIPTION
With this config file cli will be able to find the sourceDir for android. This will fix "Invariant Violation requireNativeComponent 'InteractableView' was not found in UiManager" error for RN >= 0.60.